### PR TITLE
deps: bump karaf from 4.4.4 to 4.4.6 (Java 21 support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <javax.servlet.jsp-api.version>2.3.3</javax.servlet.jsp-api.version>
     <jkube.version>1.17-SNAPSHOT</jkube.version>
     <junit.version>5.10.0</junit.version>
-    <karaf.version>4.4.4</karaf.version>
+    <karaf.version>4.4.6</karaf.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
     <openliberty.version>23.0.0.9</openliberty.version>
     <openliberty.plugin.version>3.0.1</openliberty.plugin.version>


### PR DESCRIPTION
Reates to: 
- https://github.com/eclipse-jkube/jkube/pull/3190
- https://github.com/eclipse-jkube/jkube/issues/2911
- https://github.com/eclipse-jkube/jkube/issues/2381