### PR TITLE
ci : Remove non working OpenShift 3.11.0 test jobs from Smoke testing pipeline

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -152,7 +152,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openshift: [v3.11.0,v3.10.0]
+        openshift: [v3.10.0]
         suite: ['quarkus','springboot','webapp','other']
     steps:
 #     This seems to cause problems with OpenShift Setup Action


### PR DESCRIPTION
Related to https://github.com/eclipse-jkube/jkube-integration-tests/pull/362

Smoke Tests pipeline still has OpenShift 3.11.0 in Test suite matrix.