### PR TITLE
test : Move `CompleteOcDockerLayerDisabledITCase` to a different package and make it use a different test project.

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteOcDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteOcDockerITCase.java
@@ -53,6 +53,11 @@ class CompleteOcDockerITCase extends Complete implements OpenShiftCase {
     return Collections.singletonList("OpenShift-Docker");
   }
 
+  @Override
+  public String getApplication() {
+    return "spring-boot-complete";
+  }
+
   @Test
   @Order(1)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
@@ -128,12 +133,5 @@ class CompleteOcDockerITCase extends Complete implements OpenShiftCase {
     assertJKube(this)
       .assertThatShouldDeleteAllAppliedResources();
     cleanUpCluster();
-  }
-
-  @Override
-  public void cleanUpCluster() {
-    // NO OP
-    // Don't clean up cluster to avoid removing builds and image streams for other tests
-    // TODO: Split the Complete test project by profile into multiple projects to avoid this issue
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabled.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabled.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.springboot.layeredjardisabled;
+
+import io.fabric8.junit.jupiter.api.KubernetesTest;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.eclipse.jkube.integrationtests.JKubeCase;
+import org.eclipse.jkube.integrationtests.assertions.ServiceAssertion;
+import org.eclipse.jkube.integrationtests.maven.MavenCase;
+
+import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.assertPod;
+import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.awaitPod;
+import static org.eclipse.jkube.integrationtests.assertions.ServiceAssertion.awaitService;
+import static org.hamcrest.Matchers.hasSize;
+
+@KubernetesTest(createEphemeralNamespace = false)
+abstract class LayeredJarDisabled implements JKubeCase, MavenCase {
+
+  private static final String PROJECT_LAYERED_JAR_DISABLED = "projects-to-be-tested/maven/spring/layered-jar-disabled";
+
+  private KubernetesClient kubernetesClient;
+
+  @Override
+  public KubernetesClient getKubernetesClient() {
+    return kubernetesClient;
+  }
+
+  @Override
+  public String getProject() {
+    return PROJECT_LAYERED_JAR_DISABLED;
+  }
+
+  @Override
+  public String getApplication() {
+    return "spring-boot-layered-jar-disabled";
+  }
+
+  final ServiceAssertion assertThatShouldApplyResources() throws Exception {
+    final Pod pod = awaitPod(this).getKubernetesResource();
+    assertPod(pod).apply(this).logContains("LayeredJarDisabledApplication : Started LayeredJarDisabledApplication in", 60);
+    return awaitService(this, pod.getMetadata().getNamespace())
+      .assertIsNodePort()
+      .assertPorts(hasSize(1))
+      .assertPort("http", 8080, true);
+  }
+
+}

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabledOcDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabledOcDockerITCase.java
@@ -11,7 +11,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.jkube.integrationtests.springboot.complete;
+package org.eclipse.jkube.integrationtests.springboot.layeredjardisabled;
 
 import io.fabric8.openshift.api.model.ImageStream;
 import org.apache.maven.shared.invoker.InvocationResult;
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.List;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
@@ -47,12 +45,7 @@ import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 @Tag(OPEN_SHIFT)
 @Tag(OPEN_SHIFT_OSCI)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class CompleteOcDockerLayersDisabledITCase extends Complete implements OpenShiftCase {
-  @Override
-  public List<String> getProfiles() {
-    return Collections.singletonList("OpenShift-Docker-Spring-Layers-Disabled");
-  }
-
+class LayeredJarDisabledOcDockerITCase extends LayeredJarDisabled implements OpenShiftCase {
   @Test
   @Order(1)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
@@ -68,7 +61,7 @@ class CompleteOcDockerLayersDisabledITCase extends Complete implements OpenShift
     assertOpenShiftDockerBuildCompletedWithLogs(
       "FROM quay.io/jkube/jkube-java:",
       "ENV JAVA_APP_DIR=/deployments",
-      "EXPOSE 8082 8778 9779",
+      "EXPOSE 8080 8778 9779",
       "COPY /jkube-generated-layer-original/deployments /deployments/",
       "WORKDIR /deployment");
   }
@@ -85,8 +78,9 @@ class CompleteOcDockerLayersDisabledITCase extends Complete implements OpenShift
       String.format("../%s/target/classes/META-INF", getProject()));
     assertThat(metaInfDirectory.exists(), equalTo(true));
     assertListResource(new File(metaInfDirectory, "jkube/openshift.yml"));
-    assertThat(new File(metaInfDirectory, "jkube/openshift/spring-boot-complete-deploymentconfig.yml"), yaml(not(anEmptyMap())));
-    assertThat(new File(metaInfDirectory, "jkube/openshift/spring-boot-complete-service.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube/openshift/spring-boot-layered-jar-disabled-deploymentconfig.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube/openshift/spring-boot-layered-jar-disabled-service.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube/openshift/spring-boot-layered-jar-disabled-route.yml"), yaml(not(anEmptyMap())));
   }
 
   @Test
@@ -112,7 +106,7 @@ class CompleteOcDockerLayersDisabledITCase extends Complete implements OpenShift
     // Then
     assertInvocation(invocationResult);
     assertThat(invocationResult.getStdOut(),
-      stringContainsInOrder("Tomcat started on port(s)", "Started CompleteApplication in", "seconds"));
+      stringContainsInOrder("Tomcat started on port(s)", "Started LayeredJarDisabledApplication in", "seconds"));
   }
 
   @Test
@@ -126,12 +120,5 @@ class CompleteOcDockerLayersDisabledITCase extends Complete implements OpenShift
     assertJKube(this)
       .assertThatShouldDeleteAllAppliedResources();
     cleanUpCluster();
-  }
-
-  @Override
-  public void cleanUpCluster() {
-    // NO OP
-    // Don't clean up cluster to avoid removing builds and image streams for other tests
-    // TODO: Split the Complete test project by profile into multiple projects to avoid this issue
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <javax.servlet.jsp-api.version>2.3.3</javax.servlet.jsp-api.version>
     <!-- JKube version also needs to be updated in projects-to-be-tested/maven/buildpacks/simple/pom.xml -->
-    <jkube.version>1.17-SNAPSHOT</jkube.version>
+    <jkube.version>1.18-SNAPSHOT</jkube.version>
     <junit.version>5.11.0</junit.version>
     <karaf.version>4.4.6</karaf.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
@@ -383,6 +383,7 @@
         <module>projects-to-be-tested/maven/spring/watch</module>
         <module>projects-to-be-tested/maven/spring/zero-config</module>
         <module>projects-to-be-tested/maven/spring/zero-config-fatjar</module>
+        <module>projects-to-be-tested/maven/spring/layered-jar-disabled</module>
       </modules>
       <activation>
         <file>

--- a/projects-to-be-tested/maven/spring/complete/pom.xml
+++ b/projects-to-be-tested/maven/spring/complete/pom.xml
@@ -215,53 +215,6 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>OpenShift-Docker-Spring-Layers-Disabled</id>
-      <properties>
-        <jkube.build.strategy>docker</jkube.build.strategy>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <version>${spring-boot.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>repackage</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <layers>
-                <enabled>false</enabled>
-              </layers>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.jkube</groupId>
-            <artifactId>openshift-maven-plugin</artifactId>
-            <configuration>
-              <enricher>
-                <config>
-                  <jkube-service>
-                    <type>NodePort</type>
-                  </jkube-service>
-                </config>
-              </enricher>
-              <resources>
-                <labels>
-                  <all>
-                    <jkube.spring-boot.example>complete</jkube.spring-boot.example>
-                  </all>
-                </labels>
-              </resources>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 </project>

--- a/projects-to-be-tested/maven/spring/layered-jar-disabled/pom.xml
+++ b/projects-to-be-tested/maven/spring/layered-jar-disabled/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jkube.integration-tests</groupId>
+    <artifactId>jkube-integration-tests-project</artifactId>
+    <version>${revision}</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spring-boot-layered-jar-disabled</artifactId>
+  <name>${global.name} :: Spring Boot :: Layered Jar Disabled</name>
+  <description>
+    Spring Boot with Explicit Configuration to disable Layered Jar
+  </description>
+
+  <properties>
+    <jkube.build.strategy>docker</jkube.build.strategy>
+    <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <layers>
+            <enabled>false</enabled>
+          </layers>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>openshift-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/projects-to-be-tested/maven/spring/layered-jar-disabled/src/main/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabledApplication.java
+++ b/projects-to-be-tested/maven/spring/layered-jar-disabled/src/main/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabledApplication.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.springboot.layeredjardisabled;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class LayeredJarDisabledApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(LayeredJarDisabledApplication.class, args);
+	}
+
+}

--- a/projects-to-be-tested/maven/spring/layered-jar-disabled/src/main/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabledResource.java
+++ b/projects-to-be-tested/maven/spring/layered-jar-disabled/src/main/java/org/eclipse/jkube/integrationtests/springboot/layeredjardisabled/LayeredJarDisabledResource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.springboot.layeredjardisabled;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+public class LayeredJarDisabledResource {
+
+  @GetMapping
+  public String layeredJarDisabled() {
+    return "Layered Jar is Disabled in this application";
+  }
+}


### PR DESCRIPTION
# Description
Related to https://github.com/eclipse-jkube/jkube/issues/3420

Currently, CompleteOcDockerITCase and CompleteOcDockerLayersDisabledITCase use shared project. This causes problems when these projects are run concurrently as one test overwrites build directory (fat jar) that might be currently getting used by other test (the latter one uses legacy fat jar).

+ Move CompleteOcDockerLayerDisabledITCase to a different package and make
    it use a different test project.
+ Update `jkube.version` to `1.18-SNAPSHOT`