### PR TITLE
ci : Install virtiofsd only when runner os is Ubuntu 24.04

### DIFF
--- a/.github/workflows/e2e-crc-okd-tests.yml
+++ b/.github/workflows/e2e-crc-okd-tests.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Install required virtualization software
         run: |
           sudo apt-get update
-          sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system virtiofsd
+          sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system
+          # This package may not be present depending on Ubuntu version
+          sudo apt install virtiofsd || true
           sudo usermod -a -G libvirt $USER
       - name: Remove unwanted stuff to free up disk image
         run: |
@@ -75,6 +77,19 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
 
           sudo docker image prune --all --force
 


### PR DESCRIPTION
## Description

GitHub is rolling out Ubuntu 24.04 on it's runners, sometimes runner os is selected  as 22.04 (where `virtiofsd` package required by CRC is already installed), sometimes it's 24.04 (where `virtiofsd` package is not installed)

Add a conditional `if` statement to install it only in case of 24.04