### PR TITLE
fix: accurately count copy dir statements

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteK8sITCase.java
@@ -80,6 +80,7 @@ class CompleteK8sITCase extends Complete {
     assertThat(imageFiles, hasItem("/deployments/org/springframework/boot/loader/JarLauncher.class"));
     final List<String> imageHistory = getImageHistory(String.format("%s/%s", "integration-tests", getApplication()));
     long dirCopyLayers = imageHistory.stream()
+      .filter(l -> !l.startsWith("<missing>"))
       .filter(l -> l.contains("COPY dir:"))
       .count();
     assertThat(dirCopyLayers, equalTo(4L));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sGradleITCase.java
@@ -104,6 +104,7 @@ class ZeroConfigK8sGradleITCase extends ZeroConfig {
     assertThat(imageFiles, hasItem("/deployments/org/springframework/boot/loader/JarLauncher.class"));
     final List<String> imageHistory = getImageHistory(String.format("%s/%s", "gradle", getApplication()));
     long dirCopyLayers = imageHistory.stream()
+      .filter(l -> !l.startsWith("<missing>"))
       .filter(l -> l.contains("COPY dir:"))
       .count();
     assertThat(dirCopyLayers, equalTo(3L));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sITCase.java
@@ -88,6 +88,7 @@ class ZeroConfigK8sITCase extends ZeroConfig implements MavenCase {
     assertThat(imageFiles, hasItem("/deployments/org/springframework/boot/loader/JarLauncher.class"));
     final List<String> imageHistory = getImageHistory(String.format("%s/%s", "integration-tests", getApplication()));
     long dirCopyLayers = imageHistory.stream()
+      .filter(l -> !l.startsWith("<missing>"))
       .filter(l -> l.contains("COPY dir:"))
       .count();
     assertThat(dirCopyLayers, equalTo(3L));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfigfatjar/ZeroConfigFatJarK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfigfatjar/ZeroConfigFatJarK8sITCase.java
@@ -66,6 +66,7 @@ class ZeroConfigFatJarK8sITCase extends ZeroConfigFatJar {
     assertThat(imageFiles, hasItem("/deployments/spring-boot-zero-config-fatjar-0.0.0-SNAPSHOT.jar"));
     final List<String> imageHistory = getImageHistory(String.format("%s/%s", "integration-tests", getApplication()));
     long dirCopyLayers = imageHistory.stream()
+      .filter(l -> !l.startsWith("<missing>"))
       .filter(l -> l.contains("COPY dir:"))
       .count();
     assertThat(dirCopyLayers, equalTo(1L));


### PR DESCRIPTION
Relates to https://github.com/eclipse-jkube/jkube/issues/3623